### PR TITLE
Fix refreshing SakatsuList

### DIFF
--- a/LokiPackage/Sources/Data/Sakatsu/Models/Sakatsu.swift
+++ b/LokiPackage/Sources/Data/Sakatsu/Models/Sakatsu.swift
@@ -19,8 +19,6 @@ public struct Sakatsu: Identifiable {
     }
 }
 
-extension Sakatsu: Hashable {}
-
 extension Sakatsu: Equatable {
     public static func == (lhs: Sakatsu, rhs: Sakatsu) -> Bool {
         lhs.id == rhs.id

--- a/LokiPackage/Sources/Data/Sakatsu/Models/SaunaSet.swift
+++ b/LokiPackage/Sources/Data/Sakatsu/Models/SaunaSet.swift
@@ -58,11 +58,6 @@ public struct SaunaSet: Identifiable {
     }
 }
 
-extension SaunaSet: Hashable {}
-extension SaunaSet.Sauna: Hashable {}
-extension SaunaSet.CoolBath: Hashable {}
-extension SaunaSet.Relaxation: Hashable {}
-
 extension SaunaSet: Codable {}
 extension SaunaSet.Sauna: Codable {}
 extension SaunaSet.CoolBath: Codable {}

--- a/LokiPackage/Sources/Data/Sakatsu/Models/SaunaTemperature.swift
+++ b/LokiPackage/Sources/Data/Sakatsu/Models/SaunaTemperature.swift
@@ -14,8 +14,6 @@ public struct SaunaTemperature: Identifiable {
     }
 }
 
-extension SaunaTemperature: Hashable {}
-
 extension SaunaTemperature {
     public static var sauna: Self { .init(emoji: "🔥", title: String(localized: "Sauna", bundle: .module)) }
     public static var coolBath: Self { .init(emoji: "💧", title: String(localized: "Cool bath", bundle: .module)) }

--- a/LokiPackage/Sources/Features/Sakatsu/SakatsuInput/SakatsuInputView.swift
+++ b/LokiPackage/Sources/Features/Sakatsu/SakatsuInput/SakatsuInputView.swift
@@ -78,7 +78,7 @@ private extension SakatsuInputView {
     }
 
     var saunaSetSections: some View {
-        ForEach(sakatsu.saunaSets.indexed(), id: \.element) { saunaSetIndex, saunaSet in
+        ForEach(sakatsu.saunaSets.indexed(), id: \.element.id) { saunaSetIndex, saunaSet in
             Section {
                 saunaSetItemTimeInputView(
                     saunaSetIndex: saunaSetIndex,
@@ -135,7 +135,7 @@ private extension SakatsuInputView {
 
     var temperaturesSection: some View {
         Section {
-            ForEach(sakatsu.saunaTemperatures.indexed(), id: \.element) { saunaTemperatureIndex, saunaTemperature in
+            ForEach(sakatsu.saunaTemperatures.indexed(), id: \.element.id) { saunaTemperatureIndex, saunaTemperature in
                 saunaTemperatureInputView(
                     saunaTemperatureIndex: saunaTemperatureIndex,
                     saunaTemperature: saunaTemperature,

--- a/LokiPackage/Sources/Features/Sakatsu/SakatsuList/SakatsuListView.swift
+++ b/LokiPackage/Sources/Features/Sakatsu/SakatsuList/SakatsuListView.swift
@@ -10,7 +10,7 @@ struct SakatsuListView: View {
 
     var body: some View {
         List {
-            ForEach(sakatsus.indexed(), id: \.element) { sakatsuIndex, sakatsu in
+            ForEach(sakatsus.indexed(), id: \.element.id) { sakatsuIndex, sakatsu in
                 SakatsuRowView(
                     sakatsu: sakatsu,
                     onCopySakatsuTextButtonClick: {


### PR DESCRIPTION
## Issue

- close #191

## 原因

`ForEach` の `id` に `\.element` を指定しているためだと思われる。（つまり #185 のデグレ）
`element` が更新される場合、おそらく Explicit Identity も更新され、同一の View として扱われなくなる。

## 解決策

`ForEach` の `id` に `\.element` でなく `\.element.id` を指定する。
そうすることで `element` が更新されても同一の View として扱われる。

## Reference

- https://zenn.dev/kntk/articles/1f1b40da6fe181#explicit-identity