### PR TITLE
Add accent color

### DIFF
--- a/App/Loki/Catalog/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/App/Loki/Catalog/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,6 +1,15 @@
 {
   "colors" : [
     {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.400",
+          "green" : "0.643",
+          "red" : "0.106"
+        }
+      },
       "idiom" : "universal"
     }
   ],

--- a/App/Loki/Develop/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/App/Loki/Develop/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,6 +1,15 @@
 {
   "colors" : [
     {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.400",
+          "green" : "0.643",
+          "red" : "0.106"
+        }
+      },
       "idiom" : "universal"
     }
   ],

--- a/App/Loki/Production/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/App/Loki/Production/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,6 +1,15 @@
 {
   "colors" : [
     {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.400",
+          "green" : "0.643",
+          "red" : "0.106"
+        }
+      },
       "idiom" : "universal"
     }
   ],


### PR DESCRIPTION
`#1BA466`

## Screenshots

### Light

|SakatsuList|SakatsuDetail|Settings|LicenseList|
|:--:|:--:|:--:|:--:|
|![Simulator Screenshot - iPhone SE (3rd generation) - 2023-10-01 at 22 54 02](https://github.com/uhooi/Loki/assets/21194714/d2421cd9-6fc5-402e-b2d3-94c13aee7818)|![Simulator Screenshot - iPhone SE (3rd generation) - 2023-10-01 at 22 54 06](https://github.com/uhooi/Loki/assets/21194714/b27c49e1-336c-404d-aee6-f4ca0f8a2fe9)|![Simulator Screenshot - iPhone SE (3rd generation) - 2023-10-01 at 22 54 09](https://github.com/uhooi/Loki/assets/21194714/f6dd6efe-d6c0-45fe-b602-d8646ca7bdb5)|![Simulator Screenshot - iPhone SE (3rd generation) - 2023-10-01 at 22 54 11](https://github.com/uhooi/Loki/assets/21194714/ac763e17-87d2-4fd2-a8d2-ab69e6c01b72)|

### Dark

|SakatsuList|SakatsuDetail|Settings|LicenseList|
|:--:|:--:|:--:|:--:|
|![Simulator Screenshot - iPhone SE (3rd generation) - 2023-10-01 at 22 53 34](https://github.com/uhooi/Loki/assets/21194714/1461627a-1801-47fb-9445-6162fa679405)|![Simulator Screenshot - iPhone SE (3rd generation) - 2023-10-01 at 22 53 40](https://github.com/uhooi/Loki/assets/21194714/476a6e13-685f-4057-882b-9332636512ba)|![Simulator Screenshot - iPhone SE (3rd generation) - 2023-10-01 at 22 53 46](https://github.com/uhooi/Loki/assets/21194714/fe099e58-ec8a-4493-95dc-e34b189ddb90)|![Simulator Screenshot - iPhone SE (3rd generation) - 2023-10-01 at 22 53 50](https://github.com/uhooi/Loki/assets/21194714/154c871f-103e-414c-9ef8-d85f635e824d)|

## Reference

<img width="1440" alt="image" src="https://github.com/uhooi/Loki/assets/21194714/cf0d741a-1087-4f6a-8086-386f6e90c584">
