### PR TITLE
Use M1 macOS runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   build:
     name: Build for ${{ matrix.project }}
-    runs-on: macos-13
+    runs-on: macos-14
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## References

- https://x.com/github/status/1752458943245189120
- https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/