### PR TITLE
サ活一覧の件数表示を共通化

### DIFF
--- a/LokiPackage/Sources/Features/Sakatsu/SakatsuList/SakatsuListScreen.swift
+++ b/LokiPackage/Sources/Features/Sakatsu/SakatsuList/SakatsuListScreen.swift
@@ -105,16 +105,12 @@ private extension SakatsuListScreen {
     ) -> some ToolbarContent {
         if #available(iOS 26.0, *) {
             ToolbarItem(placement: .largeSubtitle) {
-                Text("\(sakatsusCount) Sakatsu(s)", bundle: .module)
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
+                sakatsusCountText(sakatsusCount: sakatsusCount)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
 
             ToolbarItem(placement: .subtitle) {
-                Text("\(sakatsusCount) Sakatsu(s)", bundle: .module)
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
+                sakatsusCountText(sakatsusCount: sakatsusCount)
             }
 
             ToolbarItem(placement: .topBarTrailing) {
@@ -161,6 +157,13 @@ private extension SakatsuListScreen {
                 Image(systemName: colorScheme != .dark ? "gearshape" : "gearshape.fill")
             }
         }
+    }
+
+    @available(iOS 26.0, *)
+    private func sakatsusCountText(sakatsusCount: Int) -> some View {
+        Text("\(sakatsusCount) Sakatsu(s)", bundle: .module)
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
     }
 }
 


### PR DESCRIPTION
## チケット

- なし

## 仕様書・Figma

- なし

## やったこと

- サ活一覧画面の件数表示UIを共通関数に抽出

## やってないこと

- #266

## 参考リンク

- x