### PR TITLE
fix: iOS 26の保存ボタンをroleベースに変更

### DIFF
--- a/LokiPackage/Sources/Features/Sakatsu/SakatsuInput/SakatsuInputScreen.swift
+++ b/LokiPackage/Sources/Features/Sakatsu/SakatsuInput/SakatsuInputScreen.swift
@@ -71,12 +71,9 @@ private extension SakatsuInputScreen {
     ) -> some ToolbarContent {
         if #available(iOS 26.0, *) {
             ToolbarItem(placement: .topBarTrailing) {
-                Button(action: onSaveButtonClick) {
-                    Image(systemName: "checkmark")
-                }
-                .buttonStyle(.glassProminent)
-                .accessibilityLabel(String(localized: "Save", bundle: .module))
-                .disabled(saveButtonDisabled)
+                Button(role: .confirm, action: onSaveButtonClick)
+                    .accessibilityLabel(String(localized: "Save", bundle: .module))
+                    .disabled(saveButtonDisabled)
             }
 
             ToolbarItem(placement: .topBarLeading) {


### PR DESCRIPTION
## 概要

- iOS 26 の保存ボタンを `Button(role: .confirm, action:)` に変更
- 明示的な `Image` と `.glassProminent` の指定を削除
- 既存のアクセシビリティラベルと disabled 制御は維持

## 参考リンク

- https://x.com/ios_dev_alb/status/2046626804081795178?s=20