### PR TITLE
build: Logdogを0.5.0に更新

### DIFF
--- a/Loki.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Loki.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "46d4a894610dea88c6f16090667e2703eb6ad07b5f0aaae8e556d491297df223",
+  "originHash" : "6cc40a35da6763feeb27a61934dc91f7e852491b226432f80ddb20ec9d652931",
   "pins" : [
     {
       "identity" : "licensesplugin",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/uhooi/Logdog.git",
       "state" : {
-        "revision" : "bc02bf2122f9da59e99710d1abb5e55fe40c950b",
-        "version" : "0.3.0"
+        "revision" : "da322c041897e064d36ae2b7ad969de768b6dfd2",
+        "version" : "0.5.0"
       }
     },
     {

--- a/LokiPackage/Package.resolved
+++ b/LokiPackage/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "bb6c5795966de4e05096c73b6cd92718594b769072ebbf694b00bd26290184ce",
+  "originHash" : "6cc40a35da6763feeb27a61934dc91f7e852491b226432f80ddb20ec9d652931",
   "pins" : [
     {
       "identity" : "licensesplugin",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/maiyama18/LicensesPlugin",
       "state" : {
-        "revision" : "b303f6b92427d6236e63bd75b559f095101817aa",
-        "version" : "0.1.6"
+        "revision" : "3061787a7eca7ba801d7a3abccfc077053e79d73",
+        "version" : "0.2.0"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/uhooi/Logdog.git",
       "state" : {
-        "revision" : "bc02bf2122f9da59e99710d1abb5e55fe40c950b",
-        "version" : "0.3.0"
+        "revision" : "da322c041897e064d36ae2b7ad969de768b6dfd2",
+        "version" : "0.5.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/playbook-ui/playbook-ios.git",
       "state" : {
-        "revision" : "3320069508e677858a5dbfac72622b885f3b351e",
-        "version" : "0.3.3"
+        "revision" : "da86a1a533e7ab5b1203908dfbb33aa38b782421",
+        "version" : "0.4.1"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-algorithms.git",
       "state" : {
-        "revision" : "b14b7f4c528c942f121c8b860b9410b2bf57825e",
-        "version" : "1.0.0"
+        "revision" : "f6919dfc309e7f1b56224378b11e28bab5bccc42",
+        "version" : "1.2.0"
       }
     },
     {

--- a/LokiPackage/Package.swift
+++ b/LokiPackage/Package.swift
@@ -42,7 +42,7 @@ let package = Package(
     dependencies: [
         // Libraries
         .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.2.0"),
-        .package(url: "https://github.com/uhooi/Logdog.git", from: "0.3.0"),
+        .package(url: "https://github.com/uhooi/Logdog.git", from: "0.5.0"),
         .package(url: "https://github.com/playbook-ui/playbook-ios.git", from: "0.4.1"),
 
         // Plugins


### PR DESCRIPTION
## 概要
- Logdogの依存バージョンを0.5.0へ更新
- Package.resolvedのpinを最新化