### PR TITLE
Bump Xcode from 26.4 to 26.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ permissions:
   contents: read
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_26.4.app
+  DEVELOPER_DIR: /Applications/Xcode_26.6.app
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Loki（ロキ）は、サ活の記録に特化したアプリです。
 ### 必要条件
 
 - macOS 26.2+
-- Xcode 26.4 (Swift 6.3)
+- Xcode 26.6 (Swift 6.3.3)
 - Make
 - Mint
 


### PR DESCRIPTION
## チケット

- なし

## 仕様書・Figma

- なし

## やったこと

- CIで使うXcodeを26.4から26.6に更新した
- READMEの必要条件をXcode 26.6 (Swift 6.3.3)に更新した

## やってないこと

- なし

## スクリーンショット/レコード



## 参考リンク

- https://github.com/uhooi/Loki/pull/253

🤖 Generated with [Claude Code](https://claude.com/claude-code)
